### PR TITLE
Possibility to regenerate hash id

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ This is the order in which the values are taken:
 3. Config values
 4. Hashids package
 
+## Regenerating hash id
+If you wish to regenerate a hash id for a particular model with current configuration you may do so as follows:
+```php
+// This will save the new hash id directly to database
+$model->regenerateHashId();
+
+// This will just regenerate the hash id on the instance without persisting it.
+// You will need to call the save() method to persist it.
+$model->regenerateHashId(saveToDatabase: false);
+```
+
 ## Limitations
 If your model key is auto-incrementing then, at least at the moment, there are 2 round-trips to the
 database. 1st to create the model and receive the ID and then 2nd to set the hash_id based on the ID.

--- a/tests/GeneratesHashIdTest.php
+++ b/tests/GeneratesHashIdTest.php
@@ -300,4 +300,32 @@ class GeneratesHashIdTest extends TestCase
         $this->assertCount(1, $results);
         $this->assertTrue($model->is($results->first()));
     }
+
+    public function testItCanRegenerateHashIdColumn()
+    {
+        $model = TestModel::create();
+        $expectedHashId = $model->hash_id;
+
+        $model->update(['hash_id' => null]);
+        $this->assertEmpty($model->refresh()->hash_id);
+
+        $model->regenerateHashId()->refresh();
+        $this->assertSame($expectedHashId, $model->hash_id);
+        $this->assertFalse($model->isDirty(['hash_id']));
+        $this->assertTrue($model->wasChanged(['hash_id']));
+    }
+
+    public function testItCanRegenerateHashIdColumnWithoutInstantlyPersistingInDatabase()
+    {
+        $model = TestModel::create();
+        $expectedHashId = $model->hash_id;
+
+        $model->update(['hash_id' => null]);
+        $this->assertEmpty($model->refresh()->hash_id);
+
+        $model->regenerateHashId(false);
+        $this->assertSame($expectedHashId, $model->hash_id);
+        $this->assertTrue($model->isDirty(['hash_id']));
+        $this->assertTrue($model->wasChanged(['hash_id']));
+    }
 }


### PR DESCRIPTION
This PR adds the possibility to call `regenerateHashId` method on a model, which will regenerate the `hash_id` column with the current configuration. 

> It does not matter whether the `hash_id` column is filled or not. This method will regenerate it anyway.